### PR TITLE
Small fix in part-1-graphics.adoc

### DIFF
--- a/doc/part-1-graphics.adoc
+++ b/doc/part-1-graphics.adoc
@@ -213,6 +213,7 @@ white `@` on the screen until until the libtcod window gets closed:
 ----
 while !root.window_closed() {
     root.set_default_foreground(colors::WHITE);
+    root.clear();
     root.put_char(1, 1, '@', BackgroundFlag::None);
     root.flush();
     root.wait_for_keypress(true);


### PR DESCRIPTION
The reason of this change is that, without root.clear(), the '@' glyph (player character) started multiplicating on screen.