### PR TITLE
Fix next-level param order.

### DIFF
--- a/doc/part-11-dungeon-progression.adoc
+++ b/doc/part-11-dungeon-progression.adoc
@@ -38,7 +38,7 @@ easy to add this check at the end of `handle_keys`:
         object.pos() == objects[PLAYER].pos() && object.name == "stairs"
     });
     if player_on_stairs {
-        next_level(game, objects, tcod);
+        next_level(tcod, objects, game);
     }
     DidntTakeTurn
 }


### PR DESCRIPTION
(My branch was incorrectly named, but the PR title, code, and commit message are correct)

the params were switched in the use versus the definition, I just flipped one arbitrarily :)