### PR TITLE
Align initialise_fov arg w/ code and prior parts.

### DIFF
--- a/doc/part-11-dungeon-progression.adoc
+++ b/doc/part-11-dungeon-progression.adoc
@@ -59,7 +59,7 @@ fn next_level(tcod: &mut Tcod, objects: &mut Vec<Object>, game: &mut Game) {
     game.log.add("After a rare moment of peace, you descend deeper into \
                   the heart of the dungeon...", colors::RED);
     game.map = make_map(objects);
-    initialise_fov(&game.map, &mut tcod.fov);
+    initialise_fov(&game.map, tcod);
 }
 ----
 


### PR DESCRIPTION
Passing tcod.fov might be more reasonable, but it's not what the full
code for part 11 does and it's not what the earlier lessons have done.