### PR TITLE
Update tcod crate version

### DIFF
--- a/doc/part-1-graphics.adoc
+++ b/doc/part-1-graphics.adoc
@@ -114,7 +114,7 @@ Rust, you need to have it in `Cargo.toml` under `[dependencies]`:
 [source,toml]
 ----
 [dependencies]
-tcod = "0.12"
+tcod = "0.13.0"
 ----
 
 and use `extern crate` in your Rust file. Rust libraries are called


### PR DESCRIPTION
Updated the version number as "0.13" as mentioned at https://github.com/tomassedovic/tcod-rs#how-to-use-this did not work