### PR TITLE
Remove on_use type declaration

### DIFF
--- a/doc/part-10-menu-saving.adoc
+++ b/doc/part-10-menu-saving.adoc
@@ -124,7 +124,7 @@ fn use_item(inventory_id: usize, objects: &mut [Object], game: &mut Game, tcod: 
     use Item::*;
     // just call the "use_function" if it is defined
     if let Some(item) = game.inventory[inventory_id].item {  // <2>
-        let on_use: fn(usize, &mut [Object], &mut Game, &mut Tcod) -> UseResult = match item {  // <3>
+        let on_use = match item {  // <3>
             Heal => cast_heal,
             Lightning => cast_lightning,
             Confuse => cast_confuse,

--- a/doc/part-13-adventure-gear.adoc
+++ b/doc/part-13-adventure-gear.adoc
@@ -154,7 +154,7 @@ Then in the callback match in `use_item`:
 
 [source]
 ----
-let on_use: ... = match item {
+let on_use = match item {
     Heal => cast_heal,
     Lightning => cast_lightning,
     Fireball => cast_fireball,
@@ -774,7 +774,7 @@ and in `use_item`:
 
 [source]
 ----
-let on_use: ... = match item {
+let on_use = match item {
     Heal => cast_heal,
     Lightning => cast_lightning,
     Confuse => cast_confuse,

--- a/doc/part-9-spells.adoc
+++ b/doc/part-9-spells.adoc
@@ -207,67 +207,7 @@ from being destroyed in that case, like the healing potion. There are
 also a couple of new constants that have to be defined:
 `LIGHTNING_DAMAGE = 20` and `LIGHTNING_RANGE = 5`.
 
-Now we'd write the `closest_monster` method, but as soon as we start,
-we'll see Rust being unhappy about our `let on_use = match item` line
-in our `use_item` function.
-
-You'll see it if you add a dummy `closest_monster` implementation and
-try to compile:
-
-[source]
-----
-fn closest_monster(max_range: i32, objects: &mut [Object], tcod: &Tcod) -> Option<usize> {
-    unimplemented!()
-}
-----
-
-Here's the error Rust reports:
-
-----
-   Compiling roguelike-tutorial v0.1.0 (file:///home/thomas/code/roguelike-tutorial)
-src/bin/part-9-spells.rs:328:22: 331:10 error: match arms have incompatible types:
- expected `fn(usize, &mut [Object], &mut collections::vec::Vec<(collections::string::String, tcod::colors::Color)>, &mut Tcod) -> UseResult {cast_heal}`,
-    found `fn(usize, &mut [Object], &mut collections::vec::Vec<(collections::string::String, tcod::colors::Color)>, &mut Tcod) -> UseResult {cast_lightning}`
-(expected fn item,
-    found a different fn item) [E0308]
-src/bin/part-9-spells.rs:328         let on_use = match item {
-src/bin/part-9-spells.rs:329             Heal => cast_heal,
-src/bin/part-9-spells.rs:330             Lightning => cast_lightning,
-src/bin/part-9-spells.rs:331         };
-src/bin/part-9-spells.rs:328:22: 331:10 help: run `rustc --explain E0308` to see a detailed explanation
-src/bin/part-9-spells.rs:330:26: 330:40 note: match arm with an incompatible type
-src/bin/part-9-spells.rs:330             Lightning => cast_lightning,
-                                                      ^~~~~~~~~~~~~~
-src/bin/part-9-spells.rs:332:15: 332:21 error: the type of this value must be known in this context
-src/bin/part-9-spells.rs:332         match on_use(inventory_id, objects, messages, tcod) {
-                                           ^~~~~~
-----
-
-Now this may seem scary, but Rust's errors are generally quite good in
-telling you what's wrong and sometimes even how to fix it.
-
-In this case, we're apparently passing two different types to the
-`match` expression. Just like `if/else`, all branches of `match` must
-return the same type. Now in both cases we're returning a function
-with the same signature (arguments and a return value), but the two
-functions (`cast_heal` and `cast_lightning`) are actually different
-and Rust treats them as separate types.
-
-The fix here is a bit annoying but simple. We just tell rust the
-signature we expect and Rust will happily figure out that both our
-functions satisfy it:
-
-[source]
-----
-let on_use: fn(usize, &mut [Object], &mut Messages, &mut Tcod) -> UseResult = match item {
-    Heal => cast_heal,
-    Lightning => cast_lightning,
-};
-----
-
-And now we compile!
-
-So let's write that `closest_monster` properly:
+Now let's write `closest_monster`:
 
 [source]
 ----
@@ -542,7 +482,7 @@ And associate it with `cast_confuse` in the `use_item` function:
 
 [source]
 ----
-let on_use: fn(usize, &mut [Object], &mut Messages, &mut Tcod) -> UseResult = match item {
+let on_use = match item {
     Heal => cast_heal,
     Lightning => cast_lightning,
     Confuse => cast_confuse,
@@ -729,7 +669,7 @@ fix that:
 
 [source]
 ----
-let on_use: fn(usize, &mut [Object], &mut Messages, &mut Tcod) -> UseResult = match item {
+let on_use = match item {
     Heal => cast_heal,
     Lightning => cast_lightning,
     Confuse => cast_confuse,
@@ -747,7 +687,7 @@ Here's what the `on_use` bit looks like now:
 
 [source]
 ----
-let on_use: fn(usize, &mut [Object], &mut Messages, &mut Map, &mut Tcod) -> UseResult = match item {
+let on_use = match item {
     Heal => cast_heal,
     Lightning => cast_lightning,
     Confuse => cast_confuse,

--- a/src/bin/part-10-menu-saving.rs
+++ b/src/bin/part-10-menu-saving.rs
@@ -425,7 +425,7 @@ fn use_item(inventory_id: usize, objects: &mut [Object], game: &mut Game, tcod: 
     use Item::*;
     // just call the "use_function" if it is defined
     if let Some(item) = game.inventory[inventory_id].item {
-        let on_use: fn(usize, &mut [Object], &mut Game, &mut Tcod) -> UseResult = match item {
+        let on_use = match item {
             Heal => cast_heal,
             Lightning => cast_lightning,
             Confuse => cast_confuse,

--- a/src/bin/part-11-dungeon-progression.rs
+++ b/src/bin/part-11-dungeon-progression.rs
@@ -441,7 +441,7 @@ fn use_item(inventory_id: usize, objects: &mut [Object], game: &mut Game, tcod: 
     use Item::*;
     // just call the "use_function" if it is defined
     if let Some(item) = game.inventory[inventory_id].item {
-        let on_use: fn(usize, &mut [Object], &mut Game, &mut Tcod) -> UseResult = match item {
+        let on_use = match item {
             Heal => cast_heal,
             Lightning => cast_lightning,
             Confuse => cast_confuse,

--- a/src/bin/part-12-monster-item-progression.rs
+++ b/src/bin/part-12-monster-item-progression.rs
@@ -439,7 +439,7 @@ fn use_item(inventory_id: usize, objects: &mut [Object], game: &mut Game, tcod: 
     use Item::*;
     // just call the "use_function" if it is defined
     if let Some(item) = game.inventory[inventory_id].item {
-        let on_use: fn(usize, &mut [Object], &mut Game, &mut Tcod) -> UseResult = match item {
+        let on_use = match item {
             Heal => cast_heal,
             Lightning => cast_lightning,
             Confuse => cast_confuse,

--- a/src/bin/part-13-adventure-gear.rs
+++ b/src/bin/part-13-adventure-gear.rs
@@ -557,7 +557,7 @@ fn use_item(inventory_id: usize, objects: &mut [Object], game: &mut Game, tcod: 
     use Item::*;
     // just call the "use_function" if it is defined
     if let Some(item) = game.inventory[inventory_id].item {
-        let on_use: fn(usize, &mut [Object], &mut Game, &mut Tcod) -> UseResult = match item {
+        let on_use = match item {
             Heal => cast_heal,
             Lightning => cast_lightning,
             Confuse => cast_confuse,

--- a/src/bin/part-9-spells.rs
+++ b/src/bin/part-9-spells.rs
@@ -450,13 +450,12 @@ fn use_item(
     use Item::*;
     // just call the "use_function" if it is defined
     if let Some(item) = inventory[inventory_id].item {
-        let on_use: fn(usize, &mut [Object], &mut Messages, &mut Map, &mut Tcod) -> UseResult =
-            match item {
-                Heal => cast_heal,
-                Lightning => cast_lightning,
-                Confuse => cast_confuse,
-                Fireball => cast_fireball,
-            };
+        let on_use = match item {
+            Heal => cast_heal,
+            Lightning => cast_lightning,
+            Confuse => cast_confuse,
+            Fireball => cast_fireball,
+        };
         match on_use(inventory_id, objects, messages, map, tcod) {
             UseResult::UsedUp => {
                 // destroy after use, unless it was cancelled for some reason


### PR DESCRIPTION
In part 9 you write that Rust will be unhappy if one does not type
`on_use` in `use_item`. I'm going through this tutorial with the
following Rust version and it compiles just fine without the type.

It appears Rust has fixed this issue!

Rust Version: `rustc 1.34.0 (91856ed52 2019-04-10)`